### PR TITLE
Workaround for -no-pie issue

### DIFF
--- a/forward_src/makefile
+++ b/forward_src/makefile
@@ -26,13 +26,13 @@ all:	tephra2-2012
 		mv tephra2-2012 ../tephra2-2012
 
 tephra2-2012:	new_tephra.o ../common_src/parameters.h tephra2_calc.o
-		$(CC) -Wall -O3 -idirafter ../include -o tephra2-2012 new_tephra.o tephra2_calc.o -lm $(LIB)/libgc.a -ldl
+		$(CC) -no-pie -Wall -O3 -idirafter ../include -o tephra2-2012 new_tephra.o tephra2_calc.o -lm $(LIB)/libgc.a -ldl
 
 new_tephra.o:	new_tephra.c ../common_src/common_structures.h makefile
-		$(CC) -Wall -O3 -idirafter ../include -c new_tephra.c
+		$(CC) -no-pie -Wall -O3 -idirafter ../include -c new_tephra.c
 
 tephra2_calc.o:		../common_src/tephra2_calc.c ../common_src/common_structures.h makefile
-		$(CC) -Wall -O3 -idirafter ../include -c ../common_src/tephra2_calc.c
+		$(CC) -no-pie -Wall -O3 -idirafter ../include -c ../common_src/tephra2_calc.c
 
 clean:
 		rm -fv *.o

--- a/inversion_src/makefile
+++ b/inversion_src/makefile
@@ -25,7 +25,7 @@ all:  	tephra2012_inversion
 	mv tephra2012_inversion ..
 
 tephra2012_inversion:		master.o slave.o ameoba.o tephra_inversion.o minimizing_func.o tephra2_calc.o fit_tests.o
-		$(CC)  -O3 -Wall -o tephra2012_inversion \
+		$(CC) -no-pie -O3 -Wall -o tephra2012_inversion \
 		master.o\
 		slave.o\
 		ameoba.o\
@@ -35,25 +35,25 @@ tephra2012_inversion:		master.o slave.o ameoba.o tephra_inversion.o minimizing_f
 		tephra2_calc.o $(LIB)/libgc.a -ldl
 
 master.o:		master.c ../common_src/parameters.h makefile
-			$(CC) -Wall  -O3 -idirafter ../include -c master.c
+			$(CC) -no-pie -Wall  -O3 -idirafter ../include -c master.c
 
 slave.o:		slave.c ../common_src/parameters.h makefile
-			$(CC) -Wall -O3 -idirafter ../include -c slave.c
+			$(CC) -no-pie -Wall -O3 -idirafter ../include -c slave.c
 
 ameoba.o:		ameoba.c ../common_src/parameters.h makefile
-			$(CC) -Wall -idirafter ../include -c ameoba.c
+			$(CC) -no-pie -Wall -idirafter ../include -c ameoba.c
 
 fit_tests.o:		fit_tests.c ../common_src/common_structures.h makefile
-			$(CC) -Wall -idirafter ../include -c fit_tests.c
+			$(CC) -no-pie -Wall -idirafter ../include -c fit_tests.c
 			
 minimizing_func.o:	minimizing_func.c ../common_src/common_structures.h makefile 
-			$(CC) -Wall -idirafter ../include -c minimizing_func.c
+			$(CC) -no-pie -Wall -idirafter ../include -c minimizing_func.c
 
 tephra2_calc.o:	../common_src/tephra2_calc.c ../common_src/common_structures.h makefile
-			$(CC) -Wall -O3 -idirafter ../include -c ../common_src/tephra2_calc.c
+			$(CC) -no-pie -Wall -O3 -idirafter ../include -c ../common_src/tephra2_calc.c
 
 tephra_inversion.o:	tephra_inversion.c ../common_src/common_structures.h ../common_src/parameters.h ../common_src/prototypes.h makefile
-			$(CC) -Wall -O3 -idirafter ../include -c tephra_inversion.c
+			$(CC) -no-pie -Wall -O3 -idirafter ../include -c tephra_inversion.c
 
 clean:
 	rm *.o


### PR DESCRIPTION
#2 
Simply added -no-pie flag to all gcc commands in makefiles. 